### PR TITLE
Update truncation to help with name collisions

### DIFF
--- a/simple/cluster.py
+++ b/simple/cluster.py
@@ -5,7 +5,7 @@ def GenerateConfig(context):
 
     for group in context.properties['groups']:
         groupJSON = {
-            'name': context.env['deployment'] + '-' + context.properties['cluster'] + '-' + group['group'],
+            'name': '-'.join(context.env['deployment'].split("-")[-2:])[-20:] + '-' + context.properties['cluster'] + '-' + group['group'],
             'type': 'group.py',
             'properties': {
                 'serverVersion': context.properties['serverVersion'],

--- a/simple/deployment.py
+++ b/simple/deployment.py
@@ -2,7 +2,7 @@ def GenerateConfig(context):
     config={}
     config['resources'] = []
 
-    runtimeconfigName = context.env['deployment'] + '-runtimeconfig'
+    runtimeconfigName = '-'.join(context.env['deployment'].split("-")[-2:])[-20:] + '-runtimeconfig'
     runtimeconfig = {
         'name': runtimeconfigName,
         'type': 'runtimeconfig.v1beta1.config',
@@ -14,7 +14,7 @@ def GenerateConfig(context):
 
     for cluster in context.properties['clusters']:
         clusterJSON = {
-            'name': context.env['deployment'] + '-' + cluster['cluster'],
+            'name': '-'.join(context.env['deployment'].split("-")[-2:])[-20:] + '-' + cluster['cluster'],
             'type': 'cluster.py',
             'properties': {
                 'serverVersion': context.properties['serverVersion'],
@@ -29,7 +29,7 @@ def GenerateConfig(context):
         config['resources'].append(clusterJSON)
 
     firewall = {
-        'name': context.env['deployment'] + '-firewall',
+        'name': '-'.join(context.env['deployment'].split("-")[-2:])[-20:] + '-firewall',
         'type': 'compute.v1.firewall',
         'properties': {
             'sourceRanges': ['0.0.0.0/0'],

--- a/simple/group.py
+++ b/simple/group.py
@@ -7,7 +7,7 @@ def GenerateConfig(context):
     else:
         sourceImage = URL_BASE + 'couchbase-public/global/images/couchbase-ee-server-' + license + '-v20170918'
 
-    instanceTemplateName = context.env['deployment'][:9] + '-' + context.properties['cluster'] + '-' + context.properties['group'] + '-it'
+    instanceTemplateName = '-'.join(context.env['deployment'].split("-")[-2:])[-20:] + '-' + context.properties['cluster'] + '-' + context.properties['group'] + '-it'
     instanceTemplate = {
         'name': instanceTemplateName,
         'type': 'compute.v1.instanceTemplate',
@@ -48,7 +48,7 @@ def GenerateConfig(context):
         }
     }
 
-    instanceGroupManagerName = context.env['deployment'][:9] + '-' + context.properties['cluster'] + '-' + context.properties['group'] + '-igm'
+    instanceGroupManagerName = '-'.join(context.env['deployment'].split("-")[-2:])[-20:] + '-' + context.properties['cluster'] + '-' + context.properties['group'] + '-igm'
     instanceGroupManager = {
         'name': instanceGroupManagerName,
         'type': 'compute.v1.regionInstanceGroupManager',


### PR DESCRIPTION
Update references to context.env['deployment']

The changes in this PR take the deployment name, split the string on hyphens, takes the last 2 elements of the list from the split, joins them back into a string with hyphens separating them, and then truncates that to hold the last 20 chars. 

Example:
```
deps = [
        'couchbase-enterprise-edition-byol-1',
        'couchbase-enterprise-edition-hourly-pricing-1',
        'kinda-normal-name-with-hyphens',
        'longdeploymentnamewithoutspacesjustbecause',
        'this-is-really-long-with-dashes-and-stuff-to-break-but-not-today'
       ]

for i in range(0,5):
  print 'Deployment is: ' + deps[i]
  print 'Shortened : ' + '-'.join(deps[i].split('-')[-2:])[-20:]
```

Will give
```
Deployment is: couchbase-enterprise-edition-byol-1
Shortened : byol-1
Deployment is: couchbase-enterprise-edition-hourly-pricing-1
Shortened : pricing-1
Deployment is: kinda-normal-name-with-hyphens
Shortened : with-hyphens
Deployment is: longdeploymentnamewithoutspacesjustbecause
Shortened : outspacesjustbecause
Deployment is: this-is-really-long-with-dashes-and-stuff-to-break-but-not-today
Shortened : not-today
```
![keepend](https://user-images.githubusercontent.com/21086745/31363836-07738288-ad16-11e7-8813-2f6105672747.png)

![longnodash](https://user-images.githubusercontent.com/21086745/31363838-0d8a6ce0-ad16-11e7-8616-e3aa41f9a89b.png)


